### PR TITLE
Version 2.0.3

### DIFF
--- a/components/ArtistInfo.js
+++ b/components/ArtistInfo.js
@@ -24,6 +24,11 @@ function UrlIcons({artist}) {
 	return (
 		<>
 			{artist.spotifyId && <SpotifyUrlContainer id={artist.spotifyId} />}
+			{artist.spotifyIds && 
+				artist.spotifyIds.map((spotifyId) =>
+					<SpotifyUrlContainer id={spotifyId} />
+				)
+			}
 			{artist.mbid && <MusicBrainzUrlContainer id={artist.mbid} />}
 		</>
 	);
@@ -46,7 +51,7 @@ export default function ArtistInfo({artist}) {
 				{artist.imageUrl && <ImageContainer url={artist.imageUrl} />}
 				<div id="artistTextContainer" className={styles.artistTextContainer}>
 					<div className={styles.nameContainer}>
-						<h1 id="artistName" className={styles.artistName}>{artist.name}</h1>
+						<h1 id="artistName" className={styles.artistName}>{artist.name || artist.names.join(" / ")}</h1>
 						<UrlIcons artist={artist} />
 					</div>
 					<h2 id="artistFollowerCount" className={styles.artistFollowerCount}>{artist.followers} Followers</h2>

--- a/components/Export.js
+++ b/components/Export.js
@@ -7,7 +7,7 @@ import { useExport } from "./ExportState";
 export function useExportData() {
     const router = useRouter();
 
-    const { exportState, setExportState } = useExport();
+    const { exportState, setExportState, allItems } = useExport();
 
     let toastProperties = {
         position: "top-left",
@@ -19,14 +19,29 @@ export function useExportData() {
         progress: undefined,
         transition: Flip,
     }
-    const exportData = () => {
+    const exportItems = () => {
         if (router.pathname == "/artist") {
             setExportState(!exportState);
+            if (!exportState){
+                toast.info("Revealing export buttons...", toastProperties)
+            } else {
+                toast.info("Hiding export buttons...", toastProperties)
+            }
         } else {
-            toast.warn("Data export is not avaliable on this page", toastProperties);
+            toast.warn("Individual data export is not avaliable on this page", toastProperties);
             return null;
         }
     };
 
-    return exportData;
+    const exportAllItems = () => {
+        if (router.pathname == "/artist") {
+            navigator.clipboard.writeText(JSON.stringify(allItems));
+            toast.info("Copied all items to clipboard", toastProperties)
+        } else {
+            toast.warn("Full data export is not avaliable on this page", toastProperties);
+            return null;
+        }
+    }
+
+    return {exportItems, exportAllItems};
 }

--- a/components/ExportState.js
+++ b/components/ExportState.js
@@ -4,8 +4,9 @@ const ExportContext = createContext();
 
 export function ExportState({ children }) {
     const [exportState, setExportState] = useState(false);
+    const [allItems, setAllItems] = useState([]);
     return (
-        <ExportContext.Provider value={{ exportState, setExportState }}>
+        <ExportContext.Provider value={{ exportState, setExportState, allItems, setAllItems }}>
             {children}
         </ExportContext.Provider>
     );

--- a/components/ItemList.js
+++ b/components/ItemList.js
@@ -445,6 +445,10 @@ export default function ItemList({ items, type, text }) {
 	const [searchQuery, setSearchQuery] = useState(""); // State for search query
 	const [filteredItems, setFilteredItems] = useState(items || []); // State for filtered items
 	const [filter, setFilter] = useState({ showGreen: true, showOrange: true, showRed: true, showVarious: true, onlyIssues: false });
+	const { setAllItems } = useExportState();
+	if (items?.length > 0){
+		setAllItems(items);
+	}
 	useEffect(() => {
 		if (type !== "album") {
 			return;

--- a/components/Popup.js
+++ b/components/Popup.js
@@ -178,14 +178,14 @@ function ExportMenu({ data, close }) {
 							<div className={styles.property}>
 								<button
 									className={styles.copyButton}
-									onClick={() => handleCopy(String(value))}
+									onClick={() => handleCopy(Array.isArray(value) && typeof value[0] === "object" ? JSON.stringify(value, null, 2) : String(value))}
 									title="Copy to Clipboard"
 								>
 									<FaCopy />
 								</button>{" "}
 								{key}
 							</div>
-							<div className={styles.propertyData}>{String(value)}</div>
+							<div className={styles.propertyData}>{Array.isArray(value) && typeof value[0] === "object" ? JSON.stringify(value, null, 2) : String(value)}</div>
 						</div>
 					);
 				})}

--- a/components/Popup.js
+++ b/components/Popup.js
@@ -7,8 +7,10 @@ import { FaXmark, FaGear, FaFilter, FaCopy } from "react-icons/fa6";
 import { TbTableExport } from "react-icons/tb";
 import { useExport } from "./ExportState"
 import { toast, Flip } from "react-toastify"
+import getConfig from 'next/config';
 
 function ConfigureMenu({ close }) {
+	const { publicRuntimeConfig } = getConfig();
 	const { settings, updateSettings } = useSettings();
 	const [showHarmony, setShowHarmony] = useState(settings.showHarmony);
 	const [showATisket, setShowATisket] = useState(settings.showATisket);
@@ -24,7 +26,7 @@ function ConfigureMenu({ close }) {
 			{" "}
 			<div className={styles.header}>
 				{" "}
-				<FaGear /> Configure SAMBL{" "}
+				<FaGear /> Configure SAMBL <p className={styles.version}>{publicRuntimeConfig?.version}</p>
 			</div>
 			<div className={styles.content}>
 				<div className={styles.configureMenu}>

--- a/components/header.js
+++ b/components/header.js
@@ -6,7 +6,7 @@ import { Description, Dialog, DialogPanel, DialogTitle } from '@headlessui/react
 
 import { FaMagnifyingGlass, FaGear } from "react-icons/fa6";
 import { FaTools, FaUser } from "react-icons/fa";
-import { TbTableExport } from "react-icons/tb";
+import { TbTableExport, TbPackageExport } from "react-icons/tb";
 
 
 import { useExportData } from "./Export";
@@ -14,7 +14,7 @@ import { useExportData } from "./Export";
 const Popup = dynamic(() => import("./Popup"), { ssr: false });
 
 export default function Header() {
-	const exportData = useExportData();
+	const {exportItems, exportAllItems} = useExportData();
 
 	return (
 		<>
@@ -37,8 +37,13 @@ export default function Header() {
 						</MenuButton>
 						<MenuItems className={styles.dropdownMenu} transition anchor="bottom end">
 							<MenuItem>
-								<div className={styles.menuItem} onClick={exportData}>
-									<TbTableExport /> Export Data
+								<div className={styles.menuItem} onClick={exportItems}>
+									<TbPackageExport /> Export Items
+								</div>
+							</MenuItem>
+							<MenuItem>
+								<div className={styles.menuItem} onClick={exportAllItems}>
+									<TbTableExport /> Export All Items
 								</div>
 							</MenuItem>
 							<MenuItem>

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,12 @@
+const { version } = require('./package.json');
+
 module.exports = {
-    useFileSystemPublicRoutes: true,
-    i18n: {
-        locales: ['en'],
-        defaultLocale: 'en',
-      },
+  useFileSystemPublicRoutes: true,
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+  },
+  publicRuntimeConfig: {
+    version,
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "sambl-client",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "sambl-client",
-			"version": "2.0.2",
+			"version": "2.0.3",
 			"dependencies": {
 				"@headlessui/react": "^2.2.2",
 				"@types/react": "^19.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sambl-client",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"main": "/src/index.js",
 	"scripts": {
 		"build": "next build",

--- a/pages/artist/index.js
+++ b/pages/artist/index.js
@@ -97,6 +97,7 @@ function processData(sourceAlbums, mbAlbums) {
 		let spotifyImageURL = album.images[0]?.url || "";
 		let spotifyImageURL300px = album.images[1]?.url || spotifyImageURL;
 		let spotifyAlbumArtists = album.artists;
+		let spotifyArtistNames = album.artists.map(artist => artist.name);
 		let spotifyReleaseDate = album.release_date;
 		let spotifyTrackCount = album.total_tracks;
 		let spotifyAlbumType = album.album_type;
@@ -198,6 +199,7 @@ function processData(sourceAlbums, mbAlbums) {
 			spotifyImageURL,
 			spotifyImageURL300px,
 			spotifyAlbumArtists,
+			spotifyArtistNames,
 			spotifyReleaseDate,
 			spotifyTrackCount,
 			spotifyAlbumType,

--- a/pages/find/index.js
+++ b/pages/find/index.js
@@ -146,7 +146,7 @@ export default function Find() {
 	return (
 		<>
 			<Head>
-                <title>{"SAMBL • ​🅵🅸🅽🅳​"}</title>
+                <title>{"SAMBL • Find"}</title>
                 <meta name="description" content={`SAMBL - Find by ISRC, MBID, Barcode...`} />
             </Head>
 			<textarea id="findBox" rows={1} placeholder="Find by ISRC, MBID, Barcode..." defaultValue={""} />

--- a/styles/artistInfo.module.css
+++ b/styles/artistInfo.module.css
@@ -13,7 +13,7 @@
 .spURLContainer {
 	display: flex;
 	flex-direction: row;
-	padding: 1.2vh 0 0 2%;
+	padding: 1.2vh 0 0 0;
 	margin-bottom: 0;
 }
 
@@ -55,6 +55,7 @@
 .artistName {
 	margin-bottom: 0;
 	text-wrap: nowrap;
+	margin-right: 5px;
 }
 
 .artistFollowerCount {

--- a/styles/header.module.css
+++ b/styles/header.module.css
@@ -152,6 +152,8 @@
 	color: var(--button-text);
 	text-align: center;
 	font-size: 13.33px;
+	display: flex;
+	align-items: center;
 }
 
 .toolsButton:hover {
@@ -185,10 +187,6 @@
 	flex-wrap: wrap;
 	align-content: center;
 	justify-content: right;
-}
-
-.buttonText {
-	transform: translateY(-2px);
 }
 
 .dropdownWrapper {

--- a/styles/popups.module.css
+++ b/styles/popups.module.css
@@ -114,3 +114,9 @@ flex-direction: row;
     cursor: pointer;
     color: var(--foreground-secondary)
 }
+
+.version {
+    display: inline;
+    color: var(--foreground-tertiary);
+    font-size: small;
+}


### PR DESCRIPTION
- Implemented multi-artist fetching #4 49fc1ab9ec40f73ea4cc4e98f423ec1f6a505b78 b07f33eab9a6b0a8b81cea2bd1206d8421e47716
- Fixed issue with exporting the `spotifyAlbumArtists` property 40b56908c4b5ed9e0390c8c1f489d00e50389dd1
- Added parameter `spotifyArtistNames` property: Concatinates artist names as strings into an array 4e5f463c19659fb478fe2457793b59709cc25d33
- Change title of find page to plain text 23c4078346d3605e7df3214619ca0bbc6f306098
- Added display of version number in configuratino menu 4d7e6d8160a1ddcaafba0bd90f4b23ff196e3420
- Added tools option to export all items  cb2ba55d14022edfa5a1c85e0414000dc6ab2dd7
   - Rename 'Export Data' tools option to 'Export Items'
   - Added toast for the Export Items toggle