### PR TITLE
Version 2.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,30 @@ NEXT_PUBLIC_MASTODON_URL=<Mastodon URL [Optional]>
 * The Spotify Redirect URI does not need to be a valid URL, but must match your Spotify developer application
 * The contact email is for MusicBrainz's api requirements
 * MUSIXMATCH_ALTERNATE allows you to use browser cookies for an alternate authentication method
+
+## API Docs
+
+### Officially Supported API endpoints
+These API endpoints were created with public use in mind and will be fully supported for the foreseeable future
+
+ - `/find`
+   - `query` (string) [R]
+   - `type` <UPC or ISRC> [R]
+ - `/compareArtistAlbums` (beta)
+   - `spotifyId` <Spotify ID> [R]
+   - `mbid` <MBID>
+     - Only neccesary if you want to check if the associated albums are linked to that artist
+   - `quick` (bool)
+     - Uses URL matching to check for spotify album links in MusicBrainz. This returns faster, but contains less information, removing the orange album status.
+   - `full` (bool)
+     - Adds inc parameters to the MusicBrainz query. (Does not affect quick mode)
+
+### Unsupported API endpoints
+These API endpoints were created for internal use but are publically accessible for the time being. Note that these may change unexpectedly and without warning
+
+ - `getArtistAlbums`
+ - `getArtistInfo`
+ - `getMusicBrainzAlbums`
+ - `getMusicBrainzFeaturedAlbums`
+ - `lookupArtist`
+ - `searchArtists`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ SPOTIFY_REDIRECT_URI=<Spotify Redirect URI>
 CONTACT_INFO=<Contact email>
 MUSIXMATCH_API_KEY=<MusixMatch Api Key or browser cookie [Optional]>
 MUSIXMATCH_ALTERNATE=<Bool 1 or 0>
+NEXT_PUBLIC_MASTODON_URL=<Mastodon URL [Optional]>
 ```
 * The Spotify Redirect URI does not need to be a valid URL, but must match your Spotify developer application
 * The contact email is for MusicBrainz's api requirements

--- a/next.config.js
+++ b/next.config.js
@@ -8,5 +8,6 @@ module.exports = {
   },
   publicRuntimeConfig: {
     version,
+    masondonUrl: process.env.NEXT_PUBLIC_MASTODON_URL
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sambl-client",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"main": "/src/index.js",
 	"scripts": {
 		"build": "next build",

--- a/pages/api/compareArtistAlbums.js
+++ b/pages/api/compareArtistAlbums.js
@@ -1,0 +1,354 @@
+import spotify from "./providers/spotify";
+import musicbrainz from "./providers/musicbrainz";
+
+import normalizeText from "../../utils/normalizeText";
+import logger from "../../utils/logger";
+// spotifyId - Spotify artist ID
+// mbid - MusicBrainz artist ID. Only neccesary if you want to check if the associated albums are linked to that artist
+// quick - Uses URL matching to check for spotify album links in MusicBrainz. This returns faster, but contains less information, removing the orange album status.
+// full - adds inc parameters to the MusicBrainz query. (Does not affect quick mode)
+
+async function fetchSourceAlbums(artistId, offset = 0) {
+	return await spotify.getArtistAlbums(artistId, offset, 50);
+}
+
+async function fetchMbArtistAlbums(mbid, offset = 0, full = false) {
+	return await musicbrainz.getArtistAlbums(mbid, offset, 100, full ? ["url-rels", "recordings", "isrcs"] : []);
+}
+
+async function fetchMbArtistFeaturedAlbums(mbid, offset = 0, full = false) {
+	return await musicbrainz.getArtistFeaturedAlbums(mbid, offset, 100, full ? ["url-rels", "recordings", "isrcs"] : []);
+}
+
+async function getBySourceAlbumLink(links) {
+	return await musicbrainz.getAlbumsBySourceUrls(links, ["release-rels"]);
+}
+
+function processData(sourceAlbums, mbAlbums, quick = false) {
+	let albumData = [];
+	let green = 0;
+	let red = 0;
+	let orange = 0;
+	let total = 0;
+
+	sourceAlbums.forEach((album) => {
+		let albumStatus = "red";
+		let albumMBUrl = "";
+		let spotifyId = album.id;
+		let spotifyName = album.name;
+		let spotifyUrl = album.external_urls.spotify;
+		let spotifyImageURL = album.images[0]?.url || "";
+		let spotifyImageURL300px = album.images[1]?.url || spotifyImageURL;
+		let spotifyAlbumArtists = album.artists;
+		let spotifyArtistNames = album.artists.map((artist) => artist.name);
+		let spotifyReleaseDate = album.release_date;
+		let spotifyTrackCount = album.total_tracks;
+		let spotifyAlbumType = album.album_type;
+
+		let mbTrackCount = 0;
+		let mbReleaseDate = "";
+		let mbid = "";
+		let finalHasCoverArt = false;
+		let albumIssues = [];
+		let finalTracks = [];
+		let mbBarcode = "";
+		mbAlbums.forEach((mbAlbum) => {
+			let mbReleaseName = mbAlbum.title;
+			let mbReleaseUrls = mbAlbum.relations || [];
+			let MBTrackCount = mbAlbum.media?.reduce((count, media) => count + media["track-count"], 0);
+			let MBReleaseDate = mbAlbum.date;
+			let MBReleaseUPC = mbAlbum.barcode;
+			let hasCoverArt = mbAlbum["cover-art-archive"]?.front || false;
+			var MBTracks = [];
+			mbAlbum.media?.forEach((media) => {
+				if (media.tracks) {
+					MBTracks = [...MBTracks, ...media.tracks];
+				}
+			});
+			mbReleaseUrls.forEach((relation) => {
+				if (relation.url.resource == spotifyUrl) {
+					albumStatus = "green";
+					mbid = mbAlbum.id;
+					albumMBUrl = `https://musicbrainz.org/release/${mbid}`;
+					mbTrackCount = MBTrackCount;
+					mbReleaseDate = MBReleaseDate;
+					finalHasCoverArt = hasCoverArt;
+					finalTracks = MBTracks;
+					mbBarcode = MBReleaseUPC;
+				}
+			});
+
+			if (albumStatus === "red" && normalizeText(mbReleaseName) === normalizeText(spotifyName)) {
+				albumStatus = "orange";
+				mbid = mbAlbum.id;
+				albumMBUrl = `https://musicbrainz.org/release/${mbid}`;
+				mbTrackCount = MBTrackCount;
+				mbReleaseDate = MBReleaseDate;
+				finalHasCoverArt = hasCoverArt;
+				finalTracks = MBTracks;
+				mbBarcode = MBReleaseUPC;
+			}
+		});
+
+		let mbTrackNames = [];
+		let mbTrackISRCs = [];
+		let mbISRCs = [];
+		let tracksWithoutISRCs = [];
+		for (let track in finalTracks) {
+			let titleString = finalTracks[track].title;
+			let ISRCs = finalTracks[track].recording.isrcs;
+			if (ISRCs.length < 1) {
+				tracksWithoutISRCs.push(track);
+			} else {
+				mbISRCs.push(...ISRCs);
+			}
+			mbTrackNames.push(titleString);
+			mbTrackISRCs.push({ name: titleString, isrcs: ISRCs });
+		}
+
+		if (albumStatus != "red") {
+			if (!mbBarcode || mbBarcode == null) {
+				albumIssues.push("noUPC");
+			}
+			if ((mbTrackCount != spotifyTrackCount) && !quick) {
+				albumIssues.push("trackDiff");
+			}
+			if (mbReleaseDate == "" || mbReleaseDate == undefined || !mbReleaseDate) {
+				albumIssues.push("noDate");
+			} else if (mbReleaseDate != spotifyReleaseDate) {
+				albumIssues.push("dateDiff");
+			}
+			if (!finalHasCoverArt && !quick) {
+				albumIssues.push("noCover");
+			}
+			if (tracksWithoutISRCs.length > 0) {
+				albumIssues.push("missingISRCs");
+			}
+		}
+
+		total++;
+		if (albumStatus === "green") {
+			green++;
+		} else if (albumStatus === "orange") {
+			orange++;
+		} else {
+			red++;
+		}
+
+		albumData.push({
+			spotifyId,
+			spotifyName,
+			spotifyUrl,
+			spotifyImageURL,
+			spotifyImageURL300px,
+			spotifyAlbumArtists,
+			spotifyArtistNames,
+			spotifyReleaseDate,
+			spotifyTrackCount,
+			spotifyAlbumType,
+			albumStatus,
+			albumMBUrl,
+			mbTrackCount,
+			mbReleaseDate,
+			mbid,
+			albumIssues,
+			mbTrackNames,
+			mbISRCs,
+			mbTrackISRCs,
+			tracksWithoutISRCs,
+			mbBarcode,
+		});
+	});
+
+	let statusText = `Albums on MusicBrainz: ${green}/${total} ~ ${orange} albums have matching names but no associated link`;
+	return {
+		albumData,
+		statusText,
+		green,
+		orange,
+		red,
+		total,
+	};
+}
+
+export default async function handler(req, res) {
+	let sourceAlbumCount = -1;
+	let mbAlbumCount = -1;
+	let mbFeaturedAlbumCount = -1;
+	let mbUrlCount = -1;
+	let sourceAlbums = [];
+	let mbAlbums = [];
+
+	function getSourceAlbumUrls() {
+		return sourceAlbums.map((album) => {
+			return album.external_urls.spotify;
+		});
+	}
+
+	async function fetchSpotifyAlbums(spids) {
+		let attempts = 0;
+		for (const spid of spids) {
+			let offset = 0;
+			let currentAlbumCount = 999;
+			let fetchedAlbums = 0;
+			while (offset < currentAlbumCount) {
+				try {
+					const data = await fetchSourceAlbums(spid, offset);
+					if (typeof data === "number") {
+						if (data === 404) {
+							throw new Error(404);
+						}
+						throw new Error(`Error fetching Spotify albums: ${data}`);
+					}
+					sourceAlbums = [...sourceAlbums, ...data.items];
+					fetchedAlbums += data.items.length;
+					currentAlbumCount = data.total;
+					if (sourceAlbumCount < 0) {
+						sourceAlbumCount = currentAlbumCount;
+					}
+					offset = fetchedAlbums;
+					// updateLoadingText();
+				} catch (error) {
+					attempts++;
+					console.error("Error fetching albums:", error);
+				}
+				if (attempts > 3) {
+					throw new Error("Failed to fetch Spotify albums");
+					break;
+				}
+			}
+			sourceAlbumCount += currentAlbumCount;
+		}
+	}
+
+	async function fetchMusicbrainzArtistAlbums(mbid, full = false) {
+		let offset = 0;
+		let attempts = 0;
+		while (offset < mbAlbumCount || mbAlbumCount == -1) {
+			try {
+				const data = await fetchMbArtistAlbums(mbid, offset, full);
+				if (typeof data == "number") {
+					if (data == 404) {
+						throw new Error(404);
+					}
+					throw new Error(`Error fetching MusicBrainz albums: ${data}`);
+				}
+				mbAlbums = [...mbAlbums, ...data.releases];
+				mbAlbumCount = data["release-count"];
+				offset = mbAlbums.length;
+				// updateLoadingText(true);
+			} catch (error) {
+				attempts++;
+				console.error("Error fetching albums:", error);
+			}
+			if (attempts > 3) {
+				throw new Error("Failed to MusicBrainz albums");
+				break;
+			}
+		}
+	}
+
+	async function fetchMusicBrainzFeaturedAlbums(mbid, full = false) {
+		let offset = 0;
+		let attempts = 0;
+		while (offset < mbFeaturedAlbumCount || mbFeaturedAlbumCount == -1) {
+			try {
+				const data = await fetchMbArtistFeaturedAlbums(mbid, offset, full);
+				if (typeof data == "number") {
+					if (data == 404) {
+						throw new Error(404);
+					}
+					throw new Error(`Error fetching MusicBrainz Featured albums: ${data}`);
+				}
+				mbAlbums = [...mbAlbums, ...data.releases];
+				mbFeaturedAlbumCount = data["release-count"];
+				offset = mbAlbums.length;
+				// updateLoadingText(true);
+			} catch (error) {
+				attempts++;
+				console.error("Error fetching albums:", error);
+			}
+			if (attempts > 3) {
+				throw new Error("Failed to fetch MusicBrainz Featured albums");
+				return;
+			}
+		}
+	}
+
+	function processUrlObject(url) {
+		let releases = [];
+		let urlId = url.id;
+		let urlResaource = url.resource;
+		for (let relation of url.relations) {
+			let release = relation.release;
+			if (release) {
+                release.relations = [
+                    {
+                        url: {
+                            resource: urlResaource,
+                            id: urlId,
+                        },
+                    },
+                ];
+				releases.push(release);
+			}
+		}
+        return releases;
+	}
+
+	async function fetchMusicBrainzAlbumsBySourceUrls(sourceAlbumUrls) {
+		let offset = 0;
+		let attempts = 0;
+		while (offset < sourceAlbumUrls.length) {
+            console.log(offset)
+			let currentUrls = sourceAlbumUrls.slice(offset, offset + 100);
+			try {
+				const data = await getBySourceAlbumLink(currentUrls);
+				if (typeof data == "number") {
+					if (data == 404) {
+						throw new Error(404);
+					}
+					throw new Error(`Error fetching MusicBrainz albums by source URLs: ${data}`);
+				}
+				mbAlbums = [...mbAlbums, ...data.urls.flatMap((url) => (processUrlObject(url)))];
+				offset+=100;
+			} catch (error) {
+				attempts++;
+				console.error("Error fetching albums:", error);
+			}
+			if (attempts > 3) {
+				throw new Error("Failed to fetch MusicBrainz albums by URL");
+				return;
+			}
+		}
+	}
+
+	try {
+		var { spotifyId, mbid } = req.query;
+		// Check for 'quick' or 'full' in the query string
+		const quick = Object.prototype.hasOwnProperty.call(req.query, "quick");
+		const full = Object.prototype.hasOwnProperty.call(req.query, "full");
+
+		if (!spotifyId || !spotify.validateSpotifyId(spotifyId)) {
+			return res.status(400).json({ error: "Parameter `spotifyId` is missing or malformed" });
+		} else {
+			spotifyId = spotify.extractSpotifyIdFromUrl(spotifyId);
+		}
+
+		if (mbid & !musicbrainz.validateMBID(mbid) || (!quick && !mbid)) {
+			return res.status(400).json({ error: "Parameter `mbid` is missing or malformed" });
+		}
+
+		if (quick) {
+			await fetchSpotifyAlbums([spotifyId]);
+			await fetchMusicBrainzAlbumsBySourceUrls(getSourceAlbumUrls());
+		} else {
+			await Promise.all([fetchSpotifyAlbums([spotifyId]), fetchMusicbrainzArtistAlbums(mbid, full), fetchMusicBrainzFeaturedAlbums(mbid, full)]);
+		}
+		let data = await processData(sourceAlbums, mbAlbums, quick);
+		res.status(200).json(data);
+	} catch (error) {
+		logger.error("Error in matchArtistAlbumLinks API", error);
+		res.status(500).json({ error: "Internal Server Error", details: error.message });
+	}
+}

--- a/pages/api/getArtistAlbums.js
+++ b/pages/api/getArtistAlbums.js
@@ -3,10 +3,12 @@ import musicbrainz from "./providers/musicbrainz";
 
 export default async function handler(req, res) {
 	try {
-		const { spotifyId, offset, limit } = req.query;
+		var { spotifyId, offset, limit } = req.query;
 		if (!spotifyId || !spotify.validateSpotifyId(spotifyId)) {
 			return res.status(400).json({ error: "Parameter `spotifyId` is missing or malformed" });
-		}
+		} else {
+            spotifyId = spotify.extractSpotifyIdFromUrl(spotifyId);
+        }
 		const data = await spotify.getArtistAlbums(spotifyId, offset, limit);
 		res.status(200).json(data);
 	} catch (error) {

--- a/pages/api/getArtistInfo.js
+++ b/pages/api/getArtistInfo.js
@@ -3,10 +3,12 @@ import musicbrainz from "./providers/musicbrainz";
 
 export default async function handler(req, res) {
     try {
-        const { spotifyId } = req.query;
+        var { spotifyId } = req.query;
         if (!spotifyId || !spotify.validateSpotifyId(spotifyId)) {
 			return res.status(400).json({ error: "Parameter `spotifyId` is missing or malformed" });
-		}
+		} else {
+            spotifyId = spotify.extractSpotifyIdFromUrl(spotifyId);
+        }
         let spArtist = await spotify.getArtistById(spotifyId);
         if (spArtist != null) {
             return res.status(200).json(spArtist);

--- a/pages/api/lookupArtist.js
+++ b/pages/api/lookupArtist.js
@@ -3,10 +3,12 @@ import musicbrainz from "./providers/musicbrainz";
 
 export default async function handler(req, res) {
     try {
-        const { spotifyId } = req.query;
+        var { spotifyId } = req.query;
         if (!spotifyId || !spotify.validateSpotifyId(spotifyId)) {
 			return res.status(400).json({ error: "Parameter `spotifyId` is missing or malformed" });
-		}
+		} else {
+            spotifyId = spotify.extractSpotifyIdFromUrl(spotifyId);
+        }
         let spArtist = await spotify.getArtistById(spotifyId)
         if (spArtist != null) {
             let mbid = await musicbrainz.getIdBySpotifyId(spotifyId)

--- a/pages/api/providers/musicbrainz.js
+++ b/pages/api/providers/musicbrainz.js
@@ -49,10 +49,24 @@ async function getIdsBySpotifyUrls(spotifyUrls) {
 	}
 }
 
-async function getArtistAlbums(mbid, offset = 0, limit = 100) {
+async function getAlbumsBySourceUrls(sourceUrls, inc = ["release-rels"]) {
+	console.log("fbsurl")
+	try {
+		const data = await mbApi.lookupUrl(sourceUrls, inc);
+		if (data.count === 0) {
+			return null; // No albums found
+		}
+		return data;
+	} catch (error) {
+		logger.error("Failed to fetch albums by Source URLs", error);
+		throw new Error(error.message);
+	}
+}
+
+async function getArtistAlbums(mbid, offset = 0, limit = 100, inc = ["url-rels", "recordings", "isrcs"]) {
 	try {
 		// const data = await mbApi.browse('release', {artist: mbid, limit: limit, offset: offset});
-		const data = await mbApi.browse("release", { artist: mbid, limit: limit, offset: offset }, ["url-rels", "recordings", "isrcs"]);
+		const data = await mbApi.browse("release", { artist: mbid, limit: limit, offset: offset }, inc);
 		checkError(data);
 		return data;
 	} catch (error) {
@@ -61,10 +75,10 @@ async function getArtistAlbums(mbid, offset = 0, limit = 100) {
 	}
 }
 
-async function getArtistFeaturedAlbums(mbid, offset = 0, limit = 100) {
+async function getArtistFeaturedAlbums(mbid, offset = 0, limit = 100, inc = ["url-rels", "recordings", "isrcs"]) {
 	try {
 		// const data = await mbApi.browse('release', {track_artist: mbid, limit: limit, offset: offset});
-		const data = await mbApi.browse("release", { track_artist: mbid, limit: limit, offset: offset }, ["url-rels", "recordings", "isrcs"]);
+		const data = await mbApi.browse("release", { track_artist: mbid, limit: limit, offset: offset }, inc);
 		checkError(data);
 		return data;
 	} catch (error) {
@@ -114,7 +128,8 @@ const musicbrainz = {
 	getAlbumByUPC,
 	getTrackByISRC,
 	getCoverByMBID,
-	validateMBID
+	validateMBID,
+	getAlbumsBySourceUrls,
 };
 
 export default musicbrainz;

--- a/pages/api/providers/musixmatch-alt.js
+++ b/pages/api/providers/musixmatch-alt.js
@@ -28,6 +28,7 @@ async function getTrackByISRC(isrc) {
 		} else {
 			if (trackData.message.header?.status_code === 401) {
 				logger.warn(`Recieved 401 from MusixMatch. Reason: ${trackData.message.header?.hint}`);
+				throw new Error(`Recieved 401 from MusixMatch. Reason: ${trackData.message.header?.hint}`);
 			}
 			return null;
 		}

--- a/pages/api/providers/spotify.js
+++ b/pages/api/providers/spotify.js
@@ -12,9 +12,18 @@ let accessToken = null;
 let tokenExpirationTime = null;
 
 function validateSpotifyId(spotifyId) {
-    const spfPattern = /^[A-Za-z0-9]{22}$/; // Corrected regex pattern
-    return spfPattern.test(spotifyId); // Call test on the regex, not the string
+    const spfPattern = /[A-Za-z0-9]{22}/;
+    return spfPattern.test(spotifyId); 
 }
+
+function extractSpotifyIdFromUrl(url) {
+    const spfPattern = /[A-Za-z0-9]{22}$/;
+    const match = url.match(spfPattern);
+    if (match && match[0]) {
+        return match[0]; 
+    }
+}
+
 
 async function withRetry(apiCall, retries = 3, delay = 1000) {
     for (let attempt = 1; attempt <= retries; attempt++) {
@@ -131,7 +140,8 @@ const spotify = {
     getArtistAlbums,
     getAlbumByUPC,
     getTrackByISRC,
-    validateSpotifyId 
+    validateSpotifyId,
+    extractSpotifyIdFromUrl
 };
 
 export default spotify;

--- a/pages/artist/index.js
+++ b/pages/artist/index.js
@@ -6,6 +6,8 @@ import Notice from "../../components/notices";
 
 import { toast, Flip } from "react-toastify";
 
+import normalizeText from "../../utils/normalizeText";
+
 async function fetchArtistData(spfId) {
 	const response = await fetch(`http://localhost:3000/api/getArtistInfo?spotifyId=${spfId}`);
 	if (response.ok) {
@@ -272,14 +274,6 @@ function processData(sourceAlbums, mbAlbums) {
 	};
 }
 
-function normalizeText(text) {
-	let normalizedText = text.toUpperCase().replace(/\s/g, "");
-	let textRemovedChars = normalizedText.replace(/['’!?.,:;(){}\[\]<>\/\\|_\-+=*&^%$#@~`“”«»„“”¿¡]/g, "");
-	if (textRemovedChars == "") {
-		textRemovedChars = normalizedText;
-	}
-	return textRemovedChars;
-}
 
 function dispError(message) {
 	let toastProperties = {

--- a/pages/find/index.js
+++ b/pages/find/index.js
@@ -64,10 +64,19 @@ export default function Find() {
 	}
 
 	function handleResults(results){
-		if (results.length > 0) {
-			setResults(results);
+		let data = results.data || [];
+		let issues = results.issues || [];
+
+		if (data.length > 0) {
+			setResults(data);
 		} else {
 			dispError("No results found!");
+		}
+
+		if (issues.length > 0) {
+			issues.forEach((issue) => {
+				dispError(`Error with provider ${issue.provider}: ${issue.error}`, "error");
+			});
 		}
 	}
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,17 @@
-import SearchBox from '../components/SearchBox';
+import SearchBox from "../components/SearchBox";
+import Head from "next/head";
+import getConfig from "next/config";
 
 export default function Home() {
+	const { publicRuntimeConfig } = getConfig();
+	const  masondonUrl = publicRuntimeConfig?.masondonUrl || process.env.NEXT_PUBLIC_MASTODON_URL;
 	return (
 		<>
+			{masondonUrl && (
+				<Head>
+					<link rel="me" href={publicRuntimeConfig?.masondonUrl} />
+				</Head>
+			)}
 			<SearchBox />
 		</>
 	);

--- a/utils/normalizeText.js
+++ b/utils/normalizeText.js
@@ -1,0 +1,8 @@
+export default function normalizeText(text) {
+	let normalizedText = text.toUpperCase().replace(/\s/g, "");
+	let textRemovedChars = normalizedText.replace(/['’!?.,:;(){}\[\]<>\/\\|_\-+=*&^%$#@~`“”«»„“”¿¡]/g, "");
+	if (textRemovedChars == "") {
+		textRemovedChars = normalizedText;
+	}
+	return textRemovedChars;
+}


### PR DESCRIPTION
 - Add more error handling to the `/find` page
    - Updated `/find` api endpoint to return an object with `data` and `issues`
    - Updated find page front end to read the issues and display them as toasts
 - Added support for a mastodon verification URL through environment variables
    - Because why not
 - Added the `compareArtistAlbums` API endpoint
   - Basically SAMBL but an API (Thanks @RustyNova016 for bothering me to do this :3)
   - Parameters
      - `spotifyId` <Spotify ID> [Required]
      - `mbid` <MBID>
        - Only neccesary if you want to check if the associated albums are linked to that artist
      - `quick` (bool)
        - Uses URL matching to check for spotify album links in MusicBrainz. This returns faster, but contains less information, removing the orange album status.
      - `full` (bool)
        - Adds inc parameters to the MusicBrainz query. (Does not affect quick mode)
   - _**This puts in the groundwork for quick fetching!!**_
   - It's also probably buggy, so please bully it (Only bully the quick fetching though, or else it will cause problems)