### PR TITLE
chore: Added API root to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ NEXT_PUBLIC_MASTODON_URL=<Mastodon URL [Optional]>
 ## API Docs
 
 ### Officially Supported API endpoints
-These API endpoints were created with public use in mind and will be fully supported for the foreseeable future
+These API endpoints were created with public use in mind and will be fully supported for the foreseeable future.
+
+The api root is `/api/` (Ex: `https://sambl.lioncat6.com/api/find`)
 
  - `/find`
    - `query` (string) [R]


### PR DESCRIPTION
Added the API root to the readme. Only NextJS nerds know that the page router put the api in `/api/`