### PR TITLE
Refactor layout for a smaller header

### DIFF
--- a/components/ProviderPill.tsx
+++ b/components/ProviderPill.tsx
@@ -3,6 +3,7 @@ import { SiTidal, SiBandcamp, SiApplemusic } from "react-icons/si";
 import { useState, useEffect } from "react";
 import { SAMBLSettingsContext, useSettings } from "./SettingsContext";
 import styles from "../styles/ProviderPill.module.css";
+import stylesb from "../styles/ProviderPill.module.scss";
 import { ProviderDisplay } from "../types/component-types";
 import { ProviderNamespace } from "../types/provider-types";
 import clientProviders from "../utils/clientProviders";
@@ -50,13 +51,13 @@ export default function ProviderPill() {
     useEffect(() => {
         if (!loading) {
             setCurrentProvider(settings.currentProvider);
-			const params = new URLSearchParams(window.location.search);
-			if (window.location.pathname === "/search" && params.has("provider")) {
-				const providerParam = params.get("provider");
-				if (providerArray.some((p) => p.namespace === providerParam)) {
-					handleSelect(providerParam as ProviderNamespace);
-				}
-			}
+            const params = new URLSearchParams(window.location.search);
+            if (window.location.pathname === "/search" && params.has("provider")) {
+                const providerParam = params.get("provider");
+                if (providerArray.some((p) => p.namespace === providerParam)) {
+                    handleSelect(providerParam as ProviderNamespace);
+                }
+            }
         }
     }, [loading]);
 
@@ -72,8 +73,16 @@ export default function ProviderPill() {
     const selectedIndex = providerArray.findIndex((p) => p.namespace === currentProvider);
 
     return (
-        <div className={styles.ProviderPillContainer}>
-            <div className={styles.ProviderPill} style={{ position: "absolute" }}>
+        <div className={stylesb.ProviderPillContainer}>
+            <div className={stylesb.ProviderPill}>
+
+                <div
+                    className={`${styles.SelectedProvider} ${styles[currentProvider]}`}
+                    style={{
+                        left: `${selectedIndex * 30}px`,
+                    }}
+                />
+
                 {providerArray.map((element) => (
                     <button
                         className={`${styles.provider} ${styles[element.namespace]} ${currentProvider === element.namespace ? styles.selected : ""}`}
@@ -84,12 +93,7 @@ export default function ProviderPill() {
                         {element.icon}
                     </button>
                 ))}
-                <div
-                    className={`${styles.SelectedProvider} ${styles[currentProvider]}`}
-                    style={{
-                        left: `${4 + selectedIndex * 30}px`,
-                    }}
-                />
+
             </div>
         </div>
     );

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import styles from "../styles/header.module.css";
+import stylesb from "../styles/header.module.scss";
 import dynamic from "next/dynamic";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 
@@ -11,68 +12,84 @@ import ProviderPill from "./ProviderPill";
 
 import { useExportData } from "./Export";
 
-import Popup from "./Popup"
+import Popup from "./Popup";
 import ConfigureMenuPopup from "./Popups/ConfigureMenu";
+import Image from "next/image";
 
 // const Popup = dynamic(() => import("./Popup"), { ssr: false });
 
 export default function Header() {
-	const { exportItems, exportAllItems } = useExportData();
+
 
 	return (
 		<>
-			<header className={styles.header}>
+			<header className={styles.header_container}>
 				<ProviderPill />
-				<Link className={styles.samblWrapper} href="/">
-					<div className={styles.imagewrapper}>
-						<img src="assets/images/favicon.svg" alt="SAMBL Logo" className={styles.logo} />
-					</div>
-				</Link>
-				<div className={styles.textwrapper}>
-					<h1>SAMBL</h1>
-					<div className={styles.subdesc}>Streaming Artist MusicBrainz Lookup</div>
-				</div>
-				<div className={styles.buttonWrapper}>
-					<Menu as="div" className={styles.dropdownWrapper}>
-						<MenuButton className={styles.toolsButton}>
-							<div className={styles.buttonText}>
-								<FaTools /><div className={styles.collapse}> Tools</div>
-							</div>
-						</MenuButton>
-						<MenuItems className={styles.dropdownMenu} transition anchor="bottom end">
-							<MenuItem>
-								<div className={styles.menuItem} onClick={exportItems}>
-									<TbPackageExport /> Export Items
-								</div>
-							</MenuItem>
-							<MenuItem>
-								<div className={styles.menuItem} onClick={exportAllItems}>
-									<TbTableExport /> Export All Items
-								</div>
-							</MenuItem>
-							<MenuItem>
-								<Link className={styles.activeItem} href="/find">
-									<FaMagnifyingGlass /> Find
-								</Link>
-							</MenuItem>
-						</MenuItems>
-					</Menu>
-					<button className={styles.savedArtists}>
-						<div className={styles.buttonText}>
-							<FaUser /><div className={styles.collapse}> Artists</div>
-						</div>
-					</button>
-					<ConfigureMenuPopup
-						button={
-							<button className={styles.configButton}>
-								<div className={styles.buttonText}>
-									<FaGear /><div className={styles.collapse}> Configure</div>
-								</div>
-							</button>
-						}
-					/>
-				</div>
+				<Title />
+				<Buttons />
 			</header>
 		</>
 	);
+}
+
+function Title() {
+	return <>
+		<div className={styles.title_container}>
+			<Link href="/">
+				{/* <img src="assets/images/favicon.svg" alt="SAMBL Logo" className={styles.logo} /> */}
+				<Image src="assets/images/favicon.svg" alt="SAMBL Logo" width={256} height={256} className={styles.logo} />
+			</Link>
+			<div className={styles.textwrapper}>
+				<h1 className={styles.title}>SAMBL</h1>
+				<div className={stylesb.subtitle}><b>S</b>treaming <b>A</b>rtist <b>M</b>usic<b>B</b>rainz <b>L</b>ookup</div>
+			</div>
+		</div>
+	</>;
+}
+
+function Buttons() {
+	const { exportItems, exportAllItems } = useExportData();
+
+	return <>
+		<div className={styles.button_container}>
+			<Menu as="div" className={styles.dropdownWrapper}>
+				<MenuButton className={styles.toolsButton}>
+					<div className={styles.buttonText}>
+						<FaTools /><div className={stylesb.collapse}> Tools</div>
+					</div>
+				</MenuButton>
+				<MenuItems className={styles.dropdownMenu} transition anchor="bottom end">
+					<MenuItem>
+						<div className={styles.menuItem} onClick={exportItems}>
+							<TbPackageExport /> Export Items
+						</div>
+					</MenuItem>
+					<MenuItem>
+						<div className={styles.menuItem} onClick={exportAllItems}>
+							<TbTableExport /> Export All Items
+						</div>
+					</MenuItem>
+					<MenuItem>
+						<Link className={styles.activeItem} href="/find">
+							<FaMagnifyingGlass /> Find
+						</Link>
+					</MenuItem>
+				</MenuItems>
+			</Menu>
+			<button className={styles.savedArtists}>
+				<div className={styles.buttonText}>
+					<FaUser /><div className={stylesb.collapse}> Artists</div>
+				</div>
+			</button>
+			<ConfigureMenuPopup
+				button={
+					<button className={styles.configButton}>
+						<div className={styles.buttonText}>
+							<FaGear /><div className={stylesb.collapse}> Configure</div>
+						</div>
+					</button>
+				}
+			/>
+		</div>
+	</>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"react-icons": "^5.5.0",
 				"react-toastify": "^11.0.5",
 				"react-window": "^2.2.5",
+				"sass": "^1.97.3",
 				"soundcloud.ts": "^0.7.1",
 				"spotify-web-api-node": "^5.0.0",
 				"string-similarity": "^4.0.4"
@@ -825,6 +826,302 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.3",
+				"is-glob": "^4.0.3",
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.5.6",
+				"@parcel/watcher-darwin-arm64": "2.5.6",
+				"@parcel/watcher-darwin-x64": "2.5.6",
+				"@parcel/watcher-freebsd-x64": "2.5.6",
+				"@parcel/watcher-linux-arm-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm-musl": "2.5.6",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm64-musl": "2.5.6",
+				"@parcel/watcher-linux-x64-glibc": "2.5.6",
+				"@parcel/watcher-linux-x64-musl": "2.5.6",
+				"@parcel/watcher-win32-arm64": "2.5.6",
+				"@parcel/watcher-win32-ia32": "2.5.6",
+				"@parcel/watcher-win32-x64": "2.5.6"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@react-aria/focus": {
 			"version": "3.21.3",
 			"resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.3.tgz",
@@ -1193,6 +1490,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/client-only": {
@@ -1721,6 +2033,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/immutable": {
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+			"integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+			"license": "MIT"
+		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1730,6 +2048,29 @@
 			"version": "1.0.14",
 			"resolved": "https://registry.npmjs.org/is-empty-obj/-/is-empty-obj-1.0.14.tgz",
 			"integrity": "sha512-NE153YABOyMzd97pyD5QyOulWzav99vCMlFzoxJp6BScLTR6E9TrS4JGSGKeK77Ic0tUvbxRqKl2iw++d53X8A=="
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/isarray": {
 			"version": "2.0.5",
@@ -1985,6 +2326,13 @@
 				"tslib": "^2.8.0"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/node-cache": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -2124,6 +2472,19 @@
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.4.31",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -2185,6 +2546,7 @@
 			"version": "19.2.4",
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2193,6 +2555,7 @@
 			"version": "19.2.4",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -2242,6 +2605,19 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/regex-escape": {
 			"version": "3.4.11",
 			"resolved": "https://registry.npmjs.org/regex-escape/-/regex-escape-3.4.11.tgz",
@@ -2275,6 +2651,27 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"node_modules/sass": {
+			"version": "1.97.3",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+			"integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"chokidar": "^4.0.0",
+				"immutable": "^5.0.2",
+				"source-map-js": ">=0.6.2 <2.0.0"
+			},
+			"bin": {
+				"sass": "sass.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher": "^2.4.1"
+			}
 		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"react-icons": "^5.5.0",
 		"react-toastify": "^11.0.5",
 		"react-window": "^2.2.5",
+		"sass": "^1.97.3",
 		"soundcloud.ts": "^0.7.1",
 		"spotify-web-api-node": "^5.0.0",
 		"string-similarity": "^4.0.4"

--- a/styles/ProviderPill.module.css
+++ b/styles/ProviderPill.module.css
@@ -1,4 +1,4 @@
-.ProviderPill {
+/* .ProviderPill {
     display: inline-flex;
     align-items: center;
     border: 1px solid var(--foreground-secondary);
@@ -18,7 +18,7 @@
     overflow: hidden;
     flex-wrap: nowrap;
     z-index: 3;
-}
+} */
 .provider {
     border-radius: 50px;
     width: 30px;
@@ -27,10 +27,15 @@
     align-items: center;
     background-color: var(--foreground-background);
     transition: color 0.3s ease, filter 0.3s ease;
+
 }
 
 .SelectedProvider {
-    position: absolute;
+    position: relative;
+
+    /* Removes the space created by the `position: relative;`. Must be equal to the width */
+    margin-right: -30px;
+
     pointer-events: none;
     border-radius: 50px;
     width: 30px;
@@ -86,17 +91,32 @@
 }
 
 @keyframes logoShake {
-    0% { transform: rotate(0deg); }
-    25% { transform: rotate(5deg); }
-    50% { transform: rotate(-5deg); }
-    75% { transform: rotate(5deg); }
-    100% { transform: rotate(0deg); }
+    0% {
+        transform: rotate(0deg);
+    }
+
+    25% {
+        transform: rotate(5deg);
+    }
+
+    50% {
+        transform: rotate(-5deg);
+    }
+
+    75% {
+        transform: rotate(5deg);
+    }
+
+    100% {
+        transform: rotate(0deg);
+    }
 }
 
 @keyframes colorPulse {
     0% {
         filter: blur(0.2px) drop-shadow(0 0 1px currentColor);
     }
+
     100% {
         filter: blur(0.2px) drop-shadow(0 0 5px currentColor);
     }
@@ -107,24 +127,25 @@
     0% {
         opacity: 0;
     }
+
     100% {
         opacity: 1;
     }
 }
 
 @media (max-width: 800px) {
-    .ProviderPillContainer {
+    /* .ProviderPillContainer {
         width: 100%;
         bottom: 0;
         left: 0;
         position: absolute;
         display: flex;
         align-items: center;
-    }
-    .ProviderPill {
+    } */
+    /* .ProviderPill {
         position: relative !important;
         z-index: 10;
         -webkit-backdrop-filter: blur(5px);
         backdrop-filter: blur(5px);
-    }
+    } */
 }

--- a/styles/ProviderPill.module.scss
+++ b/styles/ProviderPill.module.scss
@@ -1,0 +1,26 @@
+.ProviderPillContainer {
+    order: 0;
+    margin-left: 20px;
+
+    display: flex;
+
+    @media (max-width: 938px) {
+        order: 99;
+        width: 100%;
+
+        justify-content: center;
+    }
+}
+
+.ProviderPill {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    border: 1px solid var(--foreground-secondary);
+    border-radius: 10px;
+
+    padding: 5px;
+
+    width: min-content;
+}

--- a/styles/header.module.css
+++ b/styles/header.module.css
@@ -1,24 +1,16 @@
 .textwrapper {
-	font-family: Arial, sans-serif;
-	background: transparent;
-	padding: 0;
-	justify-content: center;
 	display: flex;
-	flex-direction: column;
-	margin: auto;
-	margin-top: 18px;
-	width: 50%;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+
+	height: min-content;
+
+	font-family: Arial, sans-serif;
 	text-align: center;
 	z-index: 3;
 }
 
-
-.logo {
-	padding-top: 10px;
-	overflow: hidden;
-	width: 120px;
-	height: 120px;
-}
 
 .imagewrapper {
 	position: absolute;
@@ -144,26 +136,6 @@
 	}
 }
 
-.configButton,
-.savedArtists,
-.toolsButton {
-	position: relative;
-	right: 0;
-	margin: 10px 10px 2px 0px;
-	padding: 10px;
-	height: 32px;
-	border: 1px solid var(--button-border);
-	border-radius: 10px;
-	transition: 0.2s all;
-	background: transparent;
-	color: var(--button-text);
-	text-align: center;
-	font-size: 13.33px;
-	display: flex;
-	align-items: center;
-	z-index: 3;
-}
-
 .toolsButton:hover {
 	background: transparent;
 	border: 1px solid var(--toolsButton);
@@ -233,12 +205,71 @@
 	color: #ffffff;
 }
 
-.collapse {
-	display: inline;
+/* New header */
+
+.header_container {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+
+	width: 100%;
 }
 
-@media (max-width: 600px) {
-	.collapse {
-		display: none;
-	}
+
+/* Title */
+.title_container {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	margin: 5px 0px;
+}
+
+.logo {
+	height: 50px;
+	max-height: 10%;
+
+	width: 50px;
+
+	padding-top: 2px;
+}
+
+.title {
+	margin: 0px
+}
+
+
+
+/* Buttons */
+.button_container {
+	display: flex;
+	flex-direction: row;
+	align-content: center;
+	justify-content: right;
+
+	min-width: min-content;
+	flex-wrap: wrap;
+}
+
+.configButton,
+.savedArtists,
+.toolsButton {
+	display: flex;
+	align-items: center;
+
+	border: 1px solid var(--button-border);
+	border-radius: 10px;
+
+	margin: 0px 10px 2px 0px;
+	padding: 10px;
+	height: 32px;
+
+	text-align: center;
+	font-size: 13.33px;
+	color: var(--button-text);
+
+	transition: 0.2s all;
+	background: transparent;
 }

--- a/styles/header.module.scss
+++ b/styles/header.module.scss
@@ -1,0 +1,17 @@
+.subtitle {
+    color: #28292c;
+
+    margin-left: 20px;
+
+    @media (max-width: 728px) {
+        display: none;
+    }
+}
+
+.collapse {
+    display: inline;
+
+    @media (max-width: 440px) {
+        display: none;
+    }
+}


### PR DESCRIPTION
I often use sambl on a smaller laptop screen, but one pet peeve I have is that there's no space for the actual content. I only have 2 albums displayed!

<img width="1363" height="621" alt="image" src="https://github.com/user-attachments/assets/5bf1ca9c-905a-4862-b2db-697ef6c9f8d6" />

So I reduced the header to make it smaller. 

<img width="1357" height="600" alt="image" src="https://github.com/user-attachments/assets/fef1b741-520f-4980-9e7f-1e8cb5117b3c" />

And improve the mobile ui

<img width="474" height="512" alt="image" src="https://github.com/user-attachments/assets/2ebe575f-a7b2-4c08-ba6b-4709531f78db" />


Other changes include:
- Added Sass to allow nesting media queries inside the classes (A lot more readable IMO)
- Split some components for readbility
- Moved a lot of CSS to flexbox instead of `relative` and `absolute`
- Reordered CSS rules to keep related rules together
- New found rage toward CSSpagetti

Still need to fix the other pages as they don't auto resize...